### PR TITLE
Merge To Main: hugo config files and README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,21 +1,36 @@
-# [turmaxx.dev](https://turmaxx.dev)
+# [turmaxx.com](https://turmaxx.com)
 
-<!-- <a href="https://www.buymeacoffee.com/turmaxx" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a> -->
+<a href="https://www.buymeacoffee.com/turmaxx" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 [![Deploy Production](https://github.com/turmaxx/homepage/actions/workflows/firebase-hosting-merge.yml/badge.svg)](https://github.com/turmaxx/homepage/actions/workflows/firebase-hosting-merge.yml) [![Deploy Preview](https://github.com/turmaxx/homepage/actions/workflows/firebase-hosting-pull-request.yml/badge.svg?branch=dev&event=pull_request)](https://github.com/turmaxx/homepage/actions/workflows/firebase-hosting-pull-request.yml)
 
-Repo for my personal homepage with everything I've been up to, and where I write about stuff I am interested in. Decided to make this repo public so that people can suggest edits to articles using github.
+Repo for my personal homepage with everything I've been up to, and where I write about stuff I am interested in. Decided to make this repo public so that people can suggest edits and comment to articles using github.
 
-Powered by: [Blowfish](https://nunocoracao.github.io/blowfish/)
+Powered by: [Blowfish](https://github.com/nunocoracao/blowfish)
 
 ## Frameworks and Misc.
 These are the tools that I've used to build this...
 
-### Hugo - Framework
+| Component      | Framework    |
+| :------------- | :----------: |
+| Language       | [Go](https://go.dev/) |
+| Framework      | [Hugo](https://gohugo.io) |
+| Container      | [Docker](https://docker.com) | 
+| Theme          | [Blowfish](https://github.com/nunocoracao/blowfish) |
+| Hosting        | [Firebase](https://firbase.google.com) |
+
+<!-- 
+- [Go 🦫](https://https://go.dev)
+- [Hugo ](https://gohugo.io)
+- [Docker 🐋](https://docker.com)
+- [Blowfish 🐡](https://github.com/nunocoracao/blowfish)
+- [Firebase 🔥](https://firebase.google.com) -->
+
+<!-- ### Hugo - Framework
 https://gohugo.io
 
 ### Blowfish - Theme
 https://github.com/nunocoracao/blowfish
 
-<!-- ### Firebase - Hosting
+### Firebase - Hosting
 https://firebase.google.com/ -->

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -2,9 +2,10 @@
 # Refer to the theme docs for more details about each of these parameters.
 # https://blowfish.page/docs/getting-started/
 
-# theme = "blowfish"
-# baseURL = "https://your_domain.com/"
+# baseURL = "https://brook-s-homepage.web.app"
 defaultContentLanguage = "en"
+title = "Brook Seyoum"
+theme = "blowfish"
 
 # pluralizeListTitles = "true" # hugo function useful for non-english languages, find out more in  https://gohugo.io/getting-started/configuration/#pluralizelisttitles
 

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,0 @@
-# baseURL = "https://turmaxx.dev/"
-baseURL = "https://tubular-cranachan-7c4e1b.netlify.app"
-defaultContentLanguage = "en"
-title = "Brook Seyoum"
-theme = "blowfish"


### PR DESCRIPTION
Here are a list of changes that have been implemented on `test-branch`

- Removed `hugo.toml` from root directory and moved it to `config/_default` which contains config files for the site
- Renamed `config.toml` to `hugo.toml` and deleted the `hugo.toml that was moved from root directory.
- Updated `README.md` to my liking